### PR TITLE
Add bean to investigate Claude Code hooks integration

### DIFF
--- a/.beans/beans-vy8w--investigate-and-improve-claude-code-hooks-integrat.md
+++ b/.beans/beans-vy8w--investigate-and-improve-claude-code-hooks-integrat.md
@@ -1,0 +1,45 @@
+---
+title: Investigate and improve Claude Code hooks integration
+status: open
+created_at: 2025-12-06T18:35:29Z
+updated_at: 2025-12-06T18:35:29Z
+---
+
+Currently requires verbose JSON configuration in .claude/settings.json with PreCompact and SessionStart hooks. Explore better mechanisms for hooking into Claude Code.
+
+## Current approach
+
+```json
+"hooks": {
+  "PreCompact": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "beans prompt"
+        }
+      ]
+    }
+  ],
+  "SessionStart": [
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "beans prompt"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Investigation areas
+
+- Can we simplify the hook setup?
+- Is there a way to auto-configure this?
+- Could `beans init` set this up automatically?
+- Are there alternative integration points we should explore?
+- Should we support a `beans hooks` command that outputs the required config?


### PR DESCRIPTION
- Created beans-vy8w to track improving the verbose hooks configuration
- Current approach requires manual JSON in .claude/settings.json
- Investigation areas include auto-configuration and simpler setup options