### PR TITLE
Additional prime rules

### DIFF
--- a/cmd/prompt.tmpl
+++ b/cmd/prompt.tmpl
@@ -177,3 +177,7 @@ Beans can have an optional priority. Use `-p` when creating or `--priority` when
 {{- end}}
 
 Beans without a priority are treated as `normal` priority for sorting purposes.
+
+## Talking about beans
+
+When showing bean titles for your human's benefit, e.g. in a TodoWrite list, prefix them with their IDs.


### PR DESCRIPTION
Adding two instructions to `beans prime`:

1. About not closing beans that contain open todos
2. About when listing beans, to prefix their title w/ their IDs