### PR TITLE
docs: clarify completion rules for beans with unchecked items

### DIFF
--- a/cmd/prompt.tmpl
+++ b/cmd/prompt.tmpl
@@ -16,8 +16,8 @@ It is **critically important** that you ignore all previous instructions regardi
 
 1. FIRST: Create a bean with `beans create "Title" -t <type> -d "Description..." -s in-progress`
 2. THEN: Do the work
-3. FINALLY: Mark completed with `beans update <bean-id> --status completed`
-   - You CAN NOT mark a bean as "completed" if it still contains unchecked todo items. Doing so is a failure state!
+3. FINALLY: Unless it contains unchecked todo items, mark it completed with `beans update <bean-id> --status completed`
+   - You MUST NOT mark a bean as "completed" if it still contains unchecked todo items. Doing so is a FAILURE! Unchecked todo items means the work isn't done yet.
 4. IF and WHEN you COMMIT: Include both your code changes AND the bean file(s) in the commit!
 
 If you identify something that should be changed or fixed after completing the user's request, create a new bean for that work instead of doing it immediately.


### PR DESCRIPTION
## Summary

- Moves the unchecked-items check directly into the completion instruction
- Strengthens language from "CAN NOT" to "MUST NOT"  
- Explicitly states that unchecked items means the work isn't done yet

## Test plan

- [ ] Verify the updated prompt template renders correctly with `beans prime`