### PR TITLE
fix(cli): allow `beans version` to run without .beans directory

### DIFF
--- a/.beans/beans-nvd2--fix-beans-version-command-to-work-without-beans-di.md
+++ b/.beans/beans-nvd2--fix-beans-version-command-to-work-without-beans-di.md
@@ -1,0 +1,11 @@
+---
+# beans-nvd2
+title: Fix beans version command to work without .beans directory
+status: completed
+type: bug
+priority: normal
+created_at: 2025-12-24T22:20:21Z
+updated_at: 2025-12-24T22:21:58Z
+---
+
+The version command fails when run in a directory without .beans/ because PersistentPreRunE validates the directory exists. Add version to the exemption list in cmd/root.go.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,8 +21,8 @@ var rootCmd = &cobra.Command{
 Track your work alongside your code and supercharge your coding agent with
 a full view of your project.`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// Skip core initialization for init and prime commands
-		if cmd.Name() == "init" || cmd.Name() == "prime" {
+		// Skip core initialization for init, prime, and version commands
+		if cmd.Name() == "init" || cmd.Name() == "prime" || cmd.Name() == "version" {
 			return nil
 		}
 


### PR DESCRIPTION
The version command was failing in directories without a .beans/ subdirectory because PersistentPreRunE validates directory existence. Added "version" to the exemption list alongside "init" and "prime".