### PR TITLE
feat(tui): yank copies all selected beans, not just highlighted one

### DIFF
--- a/.beans/beans-8x3r--tui-y-should-copy-all-selected-beans-not-just-high.md
+++ b/.beans/beans-8x3r--tui-y-should-copy-all-selected-beans-not-just-high.md
@@ -1,0 +1,28 @@
+---
+# beans-8x3r
+title: 'TUI: y should copy all selected beans, not just highlighted one'
+status: completed
+type: bug
+priority: normal
+created_at: 2025-12-28T00:49:03Z
+updated_at: 2025-12-28T00:55:06Z
+---
+
+Currently y only yanks the highlighted bean. The rest of the UI supports multi-select. Yank should support multi-select as well.
+
+## Implementation Plan
+
+Make `y` (yank) in the TUI respect multi-select state, copying all selected bean IDs comma-separated instead of just the highlighted one.
+
+### Changes Required
+
+1. **`internal/tui/tui.go`**: Change `copyBeanIDMsg` from single `id string` to `ids []string`
+2. **`internal/tui/tui.go`**: Update message handler to join IDs with comma, adjust status message
+3. **`internal/tui/list.go`**: Update `y` key handler to check `selectedBeans` first (like other multi-select ops)
+4. **`internal/tui/detail.go`**: Update `y` handler to use `[]string{m.bean.ID}`
+
+### Behavior
+
+- When beans selected (space): copy all selected IDs comma-separated
+- When nothing selected: copy highlighted bean ID (unchanged)
+- Status: "Copied 3 bean IDs to clipboard" vs "Copied beans-xyz to clipboard"

--- a/internal/tui/detail.go
+++ b/internal/tui/detail.go
@@ -381,7 +381,7 @@ func (m detailModel) Update(msg tea.Msg) (detailModel, tea.Cmd) {
 		case "y":
 			// Copy bean ID to clipboard
 			return m, func() tea.Msg {
-				return copyBeanIDMsg{id: m.bean.ID}
+				return copyBeanIDMsg{ids: []string{m.bean.ID}}
 			}
 		}
 	}

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -412,10 +412,20 @@ func (m listModel) Update(msg tea.Msg) (listModel, tea.Cmd) {
 					}
 				}
 			case "y":
-				// Copy bean ID to clipboard
-				if item, ok := m.list.SelectedItem().(beanItem); ok {
+				// Copy bean ID(s) to clipboard
+				if len(m.selectedBeans) > 0 {
+					// Multi-select mode: copy all selected IDs
+					ids := make([]string, 0, len(m.selectedBeans))
+					for id := range m.selectedBeans {
+						ids = append(ids, id)
+					}
 					return m, func() tea.Msg {
-						return copyBeanIDMsg{id: item.bean.ID}
+						return copyBeanIDMsg{ids: ids}
+					}
+				} else if item, ok := m.list.SelectedItem().(beanItem); ok {
+					// Single bean mode
+					return m, func() tea.Msg {
+						return copyBeanIDMsg{ids: []string{item.bean.ID}}
 					}
 				}
 			case "esc", "backspace":

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/atotto/clipboard"
@@ -46,9 +47,9 @@ type tagSelectedMsg struct {
 // clearFilterMsg is sent to clear any active filter
 type clearFilterMsg struct{}
 
-// copyBeanIDMsg requests copying a bean ID to the clipboard
+// copyBeanIDMsg requests copying bean ID(s) to the clipboard
 type copyBeanIDMsg struct {
-	id string
+	ids []string
 }
 
 // openEditorMsg requests opening the editor for a bean
@@ -480,10 +481,13 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case copyBeanIDMsg:
 		var statusMsg string
-		if err := clipboard.WriteAll(msg.id); err != nil {
+		text := strings.Join(msg.ids, ", ")
+		if err := clipboard.WriteAll(text); err != nil {
 			statusMsg = fmt.Sprintf("Failed to copy: %v", err)
+		} else if len(msg.ids) == 1 {
+			statusMsg = fmt.Sprintf("Copied %s to clipboard", msg.ids[0])
 		} else {
-			statusMsg = fmt.Sprintf("Copied %s to clipboard", msg.id)
+			statusMsg = fmt.Sprintf("Copied %d bean IDs to clipboard", len(msg.ids))
 		}
 
 		// Set status on current view


### PR DESCRIPTION
- Change copyBeanIDMsg to hold []string instead of single string
- Update list view 'y' handler to check selectedBeans first
- Join multiple IDs with comma separator
- Show "Copied N bean IDs" for multi-select, single ID otherwise

Refs: beans-8x3r