### PR TITLE
feat(tui): space selects bean and jumps to next one

### DIFF
--- a/.beans/beans-4aid--tui-space-should-select-bean-and-jump-to-next-one.md
+++ b/.beans/beans-4aid--tui-space-should-select-bean-and-jump-to-next-one.md
@@ -1,0 +1,13 @@
+---
+# beans-4aid
+title: 'TUI: Space should select bean AND jump to next one'
+status: completed
+type: feature
+priority: normal
+created_at: 2025-12-28T01:00:18Z
+updated_at: 2025-12-28T01:03:37Z
+---
+
+When pressing space in the TUI to select a bean, it should also automatically jump to the next bean. This makes it easy to select multiple beans in sequence.
+
+Refs: https://github.com/hmans/beans/issues/35

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -268,13 +268,14 @@ func (m listModel) Update(msg tea.Msg) (listModel, tea.Cmd) {
 		if m.list.FilterState() != list.Filtering {
 			switch msg.String() {
 			case " ":
-				// Toggle selection for multi-select
+				// Toggle selection for multi-select, then move to next item
 				if item, ok := m.list.SelectedItem().(beanItem); ok {
 					if m.selectedBeans[item.bean.ID] {
 						delete(m.selectedBeans, item.bean.ID)
 					} else {
 						m.selectedBeans[item.bean.ID] = true
 					}
+					m.list.CursorDown()
 				}
 				return m, nil
 			case "enter":


### PR DESCRIPTION
Makes it easy to select multiple beans in sequence by pressing space repeatedly.

Refs: beans-4aid

🤖 Generated with [Claude Code](https://claude.com/claude-code)