### PR TITLE
feat(plugin): improve OpenCode plugin robustness with availability checks

### DIFF
--- a/.opencode/plugin/beans-prime.ts
+++ b/.opencode/plugin/beans-prime.ts
@@ -27,11 +27,11 @@ export const BeansPrimePlugin: Plugin = async ({ $, directory }) => {
   try {
     // Both conditions must be true:
     // 1. beans CLI is installed
-    // 2. beans configured for current project
+    // 2. Project has .beans.yml config
     const hasBeans = await $`which beans`.quiet();
-    const isConfigured = await $`beans check`.cwd(directory).quiet();
+    const hasConfig = await $`test -f ${directory}/.beans.yml`.quiet();
 
-    if (hasBeans.exitCode === 0 && isConfigured.exitCode === 0) {
+    if (hasBeans.exitCode === 0 && hasConfig.exitCode === 0) {
       const result = await $`beans prime`.cwd(directory).quiet();
       prime = result.stdout.toString();
     }


### PR DESCRIPTION
## Summary

Improves the OpenCode Beans Prime plugin to gracefully handle cases where the beans CLI is not installed or the current project is not configured to use beans.

## Changes

- **Availability checks**: Verifies both that the beans CLI exists (`which beans`) and that the project has beans configured (`beans check`) before attempting to load prime content
- **Error handling**: Wraps all beans commands in try-catch to prevent plugin failures
- **Correct working directory**: Uses the `directory` parameter to run beans commands in the correct project context
- **Graceful degradation**: When beans is unavailable or not configured, the plugin silently skips adding prime content rather than crashing
- **Code style**: Switches to single quotes for consistency with TypeScript conventions

## Why

Previously, the plugin would fail if:
- The beans CLI was not installed on the system
- The project opened in OpenCode didn't have beans configured
- Beans commands were run from the wrong directory

This made the plugin unreliable for general use. With these changes, the plugin now works seamlessly across all projects, only injecting beans prime content when it's actually available and appropriate.

## Testing

To test this PR:
1. Open a project without beans configured → plugin should work without errors
2. Open a project with beans configured → prime content should be injected
3. Test with beans CLI not installed → plugin should work without errors