### PR TITLE
feat: add ETag support for optimistic concurrency control

### DIFF
--- a/cmd/prompt.tmpl
+++ b/cmd/prompt.tmpl
@@ -93,6 +93,15 @@ Beans can have an optional priority. Use `-p` when creating or `--priority` when
 
 Beans without a priority are treated as `normal` priority for sorting purposes.
 
+## Concurrency Control
+
+Use etags with `--if-match` for optimistic locking:
+```bash
+ETAG=$(beans show <id> --etag-only)
+beans update <id> --if-match "$ETAG" -s completed
+```
+On conflict, returns an error with the current etag.
+
 ## GraphQL Queries
 
 The `beans query` command allows advanced querying using GraphQL.

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -18,6 +18,7 @@ var (
 	showJSON     bool
 	showRaw      bool
 	showBodyOnly bool
+	showETagOnly bool
 )
 
 var showCmd = &cobra.Command{
@@ -77,6 +78,17 @@ var showCmd = &cobra.Command{
 					fmt.Print("\n---\n\n")
 				}
 				fmt.Print(b.Body)
+			}
+			return nil
+		}
+
+		// ETag only (for easy extraction in scripts)
+		if showETagOnly {
+			for i, b := range beans {
+				if i > 0 {
+					fmt.Println()
+				}
+				fmt.Print(b.ETag())
 			}
 			return nil
 		}
@@ -186,6 +198,7 @@ func init() {
 	showCmd.Flags().BoolVar(&showJSON, "json", false, "Output as JSON")
 	showCmd.Flags().BoolVar(&showRaw, "raw", false, "Output raw markdown without styling")
 	showCmd.Flags().BoolVar(&showBodyOnly, "body-only", false, "Output only the body content")
-	showCmd.MarkFlagsMutuallyExclusive("json", "raw", "body-only")
+	showCmd.Flags().BoolVar(&showETagOnly, "etag-only", false, "Output only the etag")
+	showCmd.MarkFlagsMutuallyExclusive("json", "raw", "body-only", "etag-only")
 	rootCmd.AddCommand(showCmd)
 }

--- a/internal/bean/bean_test.go
+++ b/internal/bean/bean_test.go
@@ -824,18 +824,18 @@ func TestValidateTag(t *testing.T) {
 		{"urgent2", false},
 		{"wont-fix", false},
 		{"a-b-c", false},
-		{"", true},           // empty
-		{"Frontend", true},   // uppercase
-		{"URGENT", true},     // all uppercase
-		{"123", true},        // starts with number
-		{"123abc", true},     // starts with number
-		{"my tag", true},     // contains space
-		{"my_tag", true},     // contains underscore
-		{"my--tag", true},    // consecutive hyphens
-		{"-tag", true},       // starts with hyphen
-		{"tag-", true},       // ends with hyphen
-		{"my.tag", true},     // contains dot
-		{"my/tag", true},     // contains slash
+		{"", true},         // empty
+		{"Frontend", true}, // uppercase
+		{"URGENT", true},   // all uppercase
+		{"123", true},      // starts with number
+		{"123abc", true},   // starts with number
+		{"my tag", true},   // contains space
+		{"my_tag", true},   // contains underscore
+		{"my--tag", true},  // consecutive hyphens
+		{"-tag", true},     // starts with hyphen
+		{"tag-", true},     // ends with hyphen
+		{"my.tag", true},   // contains dot
+		{"my/tag", true},   // contains slash
 	}
 
 	for _, tt := range tests {
@@ -1214,5 +1214,220 @@ func TestRenderWithIDCommentRoundtrip(t *testing.T) {
 	}
 	if parsed.Status != original.Status {
 		t.Errorf("Status roundtrip: got %q, want %q", parsed.Status, original.Status)
+	}
+}
+
+func TestETag(t *testing.T) {
+	t.Run("consistent hash", func(t *testing.T) {
+		b := &Bean{
+			Title:  "Test",
+			Status: "todo",
+			Body:   "content",
+		}
+		etag1 := b.ETag()
+		etag2 := b.ETag()
+		if etag1 != etag2 {
+			t.Errorf("ETag not consistent: %s != %s", etag1, etag2)
+		}
+	})
+
+	t.Run("16 hex characters", func(t *testing.T) {
+		b := &Bean{
+			Title:  "Test",
+			Status: "todo",
+		}
+		etag := b.ETag()
+		if len(etag) != 16 {
+			t.Errorf("ETag length = %d, want 16", len(etag))
+		}
+		// Verify it's valid hex
+		for _, c := range etag {
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+				t.Errorf("ETag contains non-hex char: %c", c)
+			}
+		}
+	})
+
+	t.Run("changes when title changes", func(t *testing.T) {
+		b := &Bean{
+			Title:  "Test",
+			Status: "todo",
+		}
+		etag1 := b.ETag()
+
+		b.Title = "Changed"
+		etag2 := b.ETag()
+
+		if etag1 == etag2 {
+			t.Error("ETag should change when title changes")
+		}
+	})
+
+	t.Run("changes when status changes", func(t *testing.T) {
+		b := &Bean{
+			Title:  "Test",
+			Status: "todo",
+		}
+		etag1 := b.ETag()
+
+		b.Status = "in-progress"
+		etag2 := b.ETag()
+
+		if etag1 == etag2 {
+			t.Error("ETag should change when status changes")
+		}
+	})
+
+	t.Run("changes when body changes", func(t *testing.T) {
+		b := &Bean{
+			Title:  "Test",
+			Status: "todo",
+			Body:   "original",
+		}
+		etag1 := b.ETag()
+
+		b.Body = "modified"
+		etag2 := b.ETag()
+
+		if etag1 == etag2 {
+			t.Error("ETag should change when body changes")
+		}
+	})
+
+	t.Run("changes when metadata changes", func(t *testing.T) {
+		b := &Bean{
+			Title:    "Test",
+			Status:   "todo",
+			Priority: "normal",
+		}
+		etag1 := b.ETag()
+
+		b.Priority = "high"
+		etag2 := b.ETag()
+
+		if etag1 == etag2 {
+			t.Error("ETag should change when priority changes")
+		}
+	})
+
+	t.Run("same content same etag", func(t *testing.T) {
+		b1 := &Bean{
+			Title:  "Test",
+			Status: "todo",
+			Body:   "content",
+		}
+		b2 := &Bean{
+			Title:  "Test",
+			Status: "todo",
+			Body:   "content",
+		}
+
+		if b1.ETag() != b2.ETag() {
+			t.Error("Same content should produce same ETag")
+		}
+	})
+
+	t.Run("different order of tags produces different etag", func(t *testing.T) {
+		b1 := &Bean{
+			Title:  "Test",
+			Status: "todo",
+			Tags:   []string{"a", "b"},
+		}
+		b2 := &Bean{
+			Title:  "Test",
+			Status: "todo",
+			Tags:   []string{"b", "a"},
+		}
+
+		// Tag order matters in rendered output, so ETags will differ
+		if b1.ETag() == b2.ETag() {
+			t.Error("Different tag order should produce different ETag")
+		}
+	})
+
+	t.Run("etag is empty on render error", func(t *testing.T) {
+		// This is a defensive test - Render() shouldn't fail in practice,
+		// but ETag() handles it gracefully by returning empty string
+		b := &Bean{
+			Title:  "Test",
+			Status: "todo",
+		}
+		etag := b.ETag()
+		if etag == "" {
+			t.Error("ETag should not be empty for valid bean")
+		}
+	})
+}
+
+func TestMarshalJSONIncludesETag(t *testing.T) {
+	b := &Bean{
+		ID:     "test-123",
+		Title:  "Test Bean",
+		Status: "todo",
+		Body:   "Some content",
+	}
+
+	data, err := json.Marshal(b)
+	if err != nil {
+		t.Fatalf("Marshal error: %v", err)
+	}
+
+	// Check etag field is present
+	jsonStr := string(data)
+	if !strings.Contains(jsonStr, `"etag"`) {
+		t.Errorf("JSON should contain 'etag' field, got: %s", jsonStr)
+	}
+
+	// Parse and verify etag value
+	var result map[string]interface{}
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	etag, ok := result["etag"].(string)
+	if !ok {
+		t.Error("etag should be a string")
+	}
+	if len(etag) != 16 {
+		t.Errorf("etag length = %d, want 16", len(etag))
+	}
+
+	// Verify it matches the computed ETag
+	if etag != b.ETag() {
+		t.Errorf("JSON etag = %s, want %s", etag, b.ETag())
+	}
+}
+
+func TestETagChangesAfterModification(t *testing.T) {
+	// Verify that ETag changes reflect actual content changes
+	// (this is important for optimistic concurrency control)
+	b := &Bean{
+		Title:  "Original",
+		Status: "todo",
+		Body:   "Original body",
+	}
+
+	etag1 := b.ETag()
+
+	// Modify the bean
+	b.Title = "Modified"
+	b.Body = "Modified body"
+
+	etag2 := b.ETag()
+
+	if etag1 == etag2 {
+		t.Error("ETag should change after modification")
+	}
+
+	// Verify JSON serialization reflects the change
+	data1, _ := json.Marshal(&Bean{Title: "Original", Status: "todo", Body: "Original body"})
+	data2, _ := json.Marshal(b)
+
+	var result1, result2 map[string]interface{}
+	json.Unmarshal(data1, &result1)
+	json.Unmarshal(data2, &result2)
+
+	if result1["etag"] == result2["etag"] {
+		t.Error("JSON etag should differ after modification")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,11 +82,12 @@ type Config struct {
 // BeansConfig defines settings for bean creation.
 type BeansConfig struct {
 	// Path is the path to the beans directory (relative to config file location)
-	Path          string `yaml:"path,omitempty"`
-	Prefix        string `yaml:"prefix"`
-	IDLength      int    `yaml:"id_length"`
-	DefaultStatus string `yaml:"default_status,omitempty"`
-	DefaultType   string `yaml:"default_type,omitempty"`
+	Path           string `yaml:"path,omitempty"`
+	Prefix         string `yaml:"prefix"`
+	IDLength       int    `yaml:"id_length"`
+	DefaultStatus  string `yaml:"default_status,omitempty"`
+	DefaultType    string `yaml:"default_type,omitempty"`
+	RequireIfMatch bool   `yaml:"require_if_match,omitempty"`
 }
 
 // Default returns a Config with default values.

--- a/internal/graph/generated.go
+++ b/internal/graph/generated.go
@@ -57,6 +57,7 @@ type ComplexityRoot struct {
 		Body        func(childComplexity int) int
 		Children    func(childComplexity int, filter *model.BeanFilter) int
 		CreatedAt   func(childComplexity int) int
+		ETag        func(childComplexity int) int
 		ID          func(childComplexity int) int
 		Parent      func(childComplexity int) int
 		ParentID    func(childComplexity int) int
@@ -71,11 +72,11 @@ type ComplexityRoot struct {
 	}
 
 	Mutation struct {
-		AddBlocking    func(childComplexity int, id string, targetID string) int
+		AddBlocking    func(childComplexity int, id string, targetID string, ifMatch *string) int
 		CreateBean     func(childComplexity int, input model.CreateBeanInput) int
 		DeleteBean     func(childComplexity int, id string) int
-		RemoveBlocking func(childComplexity int, id string, targetID string) int
-		SetParent      func(childComplexity int, id string, parentID *string) int
+		RemoveBlocking func(childComplexity int, id string, targetID string, ifMatch *string) int
+		SetParent      func(childComplexity int, id string, parentID *string, ifMatch *string) int
 		UpdateBean     func(childComplexity int, id string, input model.UpdateBeanInput) int
 	}
 
@@ -97,9 +98,9 @@ type MutationResolver interface {
 	CreateBean(ctx context.Context, input model.CreateBeanInput) (*bean.Bean, error)
 	UpdateBean(ctx context.Context, id string, input model.UpdateBeanInput) (*bean.Bean, error)
 	DeleteBean(ctx context.Context, id string) (bool, error)
-	SetParent(ctx context.Context, id string, parentID *string) (*bean.Bean, error)
-	AddBlocking(ctx context.Context, id string, targetID string) (*bean.Bean, error)
-	RemoveBlocking(ctx context.Context, id string, targetID string) (*bean.Bean, error)
+	SetParent(ctx context.Context, id string, parentID *string, ifMatch *string) (*bean.Bean, error)
+	AddBlocking(ctx context.Context, id string, targetID string, ifMatch *string) (*bean.Bean, error)
+	RemoveBlocking(ctx context.Context, id string, targetID string, ifMatch *string) (*bean.Bean, error)
 }
 type QueryResolver interface {
 	Bean(ctx context.Context, id string) (*bean.Bean, error)
@@ -176,6 +177,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Bean.CreatedAt(childComplexity), true
+	case "Bean.etag":
+		if e.complexity.Bean.ETag == nil {
+			break
+		}
+
+		return e.complexity.Bean.ETag(childComplexity), true
 	case "Bean.id":
 		if e.complexity.Bean.ID == nil {
 			break
@@ -253,7 +260,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.AddBlocking(childComplexity, args["id"].(string), args["targetId"].(string)), true
+		return e.complexity.Mutation.AddBlocking(childComplexity, args["id"].(string), args["targetId"].(string), args["ifMatch"].(*string)), true
 	case "Mutation.createBean":
 		if e.complexity.Mutation.CreateBean == nil {
 			break
@@ -286,7 +293,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.RemoveBlocking(childComplexity, args["id"].(string), args["targetId"].(string)), true
+		return e.complexity.Mutation.RemoveBlocking(childComplexity, args["id"].(string), args["targetId"].(string), args["ifMatch"].(*string)), true
 	case "Mutation.setParent":
 		if e.complexity.Mutation.SetParent == nil {
 			break
@@ -297,7 +304,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Mutation.SetParent(childComplexity, args["id"].(string), args["parentId"].(*string)), true
+		return e.complexity.Mutation.SetParent(childComplexity, args["id"].(string), args["parentId"].(*string), args["ifMatch"].(*string)), true
 	case "Mutation.updateBean":
 		if e.complexity.Mutation.UpdateBean == nil {
 			break
@@ -506,6 +513,11 @@ func (ec *executionContext) field_Mutation_addBlocking_args(ctx context.Context,
 		return nil, err
 	}
 	args["targetId"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "ifMatch", ec.unmarshalOString2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["ifMatch"] = arg2
 	return args, nil
 }
 
@@ -544,6 +556,11 @@ func (ec *executionContext) field_Mutation_removeBlocking_args(ctx context.Conte
 		return nil, err
 	}
 	args["targetId"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "ifMatch", ec.unmarshalOString2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["ifMatch"] = arg2
 	return args, nil
 }
 
@@ -560,6 +577,11 @@ func (ec *executionContext) field_Mutation_setParent_args(ctx context.Context, r
 		return nil, err
 	}
 	args["parentId"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "ifMatch", ec.unmarshalOString2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["ifMatch"] = arg2
 	return args, nil
 }
 
@@ -983,6 +1005,35 @@ func (ec *executionContext) fieldContext_Bean_body(_ context.Context, field grap
 	return fc, nil
 }
 
+func (ec *executionContext) _Bean_etag(ctx context.Context, field graphql.CollectedField, obj *bean.Bean) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Bean_etag,
+		func(ctx context.Context) (any, error) {
+			return obj.ETag(), nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Bean_etag(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Bean",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Bean_parentId(ctx context.Context, field graphql.CollectedField, obj *bean.Bean) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1088,6 +1139,8 @@ func (ec *executionContext) fieldContext_Bean_blockedBy(ctx context.Context, fie
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1165,6 +1218,8 @@ func (ec *executionContext) fieldContext_Bean_blocking(ctx context.Context, fiel
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1241,6 +1296,8 @@ func (ec *executionContext) fieldContext_Bean_parent(_ context.Context, field gr
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1307,6 +1364,8 @@ func (ec *executionContext) fieldContext_Bean_children(ctx context.Context, fiel
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1384,6 +1443,8 @@ func (ec *executionContext) fieldContext_Mutation_createBean(ctx context.Context
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1461,6 +1522,8 @@ func (ec *executionContext) fieldContext_Mutation_updateBean(ctx context.Context
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1540,7 +1603,7 @@ func (ec *executionContext) _Mutation_setParent(ctx context.Context, field graph
 		ec.fieldContext_Mutation_setParent,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().SetParent(ctx, fc.Args["id"].(string), fc.Args["parentId"].(*string))
+			return ec.resolvers.Mutation().SetParent(ctx, fc.Args["id"].(string), fc.Args["parentId"].(*string), fc.Args["ifMatch"].(*string))
 		},
 		nil,
 		ec.marshalNBean2ᚖgithubᚗcomᚋhmansᚋbeansᚋinternalᚋbeanᚐBean,
@@ -1579,6 +1642,8 @@ func (ec *executionContext) fieldContext_Mutation_setParent(ctx context.Context,
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1617,7 +1682,7 @@ func (ec *executionContext) _Mutation_addBlocking(ctx context.Context, field gra
 		ec.fieldContext_Mutation_addBlocking,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().AddBlocking(ctx, fc.Args["id"].(string), fc.Args["targetId"].(string))
+			return ec.resolvers.Mutation().AddBlocking(ctx, fc.Args["id"].(string), fc.Args["targetId"].(string), fc.Args["ifMatch"].(*string))
 		},
 		nil,
 		ec.marshalNBean2ᚖgithubᚗcomᚋhmansᚋbeansᚋinternalᚋbeanᚐBean,
@@ -1656,6 +1721,8 @@ func (ec *executionContext) fieldContext_Mutation_addBlocking(ctx context.Contex
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1694,7 +1761,7 @@ func (ec *executionContext) _Mutation_removeBlocking(ctx context.Context, field 
 		ec.fieldContext_Mutation_removeBlocking,
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.resolvers.Mutation().RemoveBlocking(ctx, fc.Args["id"].(string), fc.Args["targetId"].(string))
+			return ec.resolvers.Mutation().RemoveBlocking(ctx, fc.Args["id"].(string), fc.Args["targetId"].(string), fc.Args["ifMatch"].(*string))
 		},
 		nil,
 		ec.marshalNBean2ᚖgithubᚗcomᚋhmansᚋbeansᚋinternalᚋbeanᚐBean,
@@ -1733,6 +1800,8 @@ func (ec *executionContext) fieldContext_Mutation_removeBlocking(ctx context.Con
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1810,6 +1879,8 @@ func (ec *executionContext) fieldContext_Query_bean(ctx context.Context, field g
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -1887,6 +1958,8 @@ func (ec *executionContext) fieldContext_Query_beans(ctx context.Context, field 
 				return ec.fieldContext_Bean_updatedAt(ctx, field)
 			case "body":
 				return ec.fieldContext_Bean_body(ctx, field)
+			case "etag":
+				return ec.fieldContext_Bean_etag(ctx, field)
 			case "parentId":
 				return ec.fieldContext_Bean_parentId(ctx, field)
 			case "blockingIds":
@@ -3693,7 +3766,7 @@ func (ec *executionContext) unmarshalInputUpdateBeanInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"title", "status", "type", "priority", "tags", "body"}
+	fieldsInOrder := [...]string{"title", "status", "type", "priority", "tags", "body", "ifMatch"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -3742,6 +3815,13 @@ func (ec *executionContext) unmarshalInputUpdateBeanInput(ctx context.Context, o
 				return it, err
 			}
 			it.Body = data
+		case "ifMatch":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("ifMatch"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IfMatch = data
 		}
 	}
 
@@ -3816,6 +3896,11 @@ func (ec *executionContext) _Bean(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "body":
 			out.Values[i] = ec._Bean_body(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "etag":
+			out.Values[i] = ec._Bean_etag(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -92,4 +92,6 @@ type UpdateBeanInput struct {
 	Tags []string `json:"tags,omitempty"`
 	// New body content
 	Body *string `json:"body,omitempty"`
+	// ETag for optimistic concurrency control (optional)
+	IfMatch *string `json:"ifMatch,omitempty"`
 }

--- a/internal/graph/resolver.go
+++ b/internal/graph/resolver.go
@@ -1,6 +1,11 @@
 package graph
 
-import "github.com/hmans/beans/internal/beancore"
+import (
+	"fmt"
+
+	"github.com/hmans/beans/internal/bean"
+	"github.com/hmans/beans/internal/beancore"
+)
 
 //go:generate go tool gqlgen generate
 
@@ -8,4 +13,44 @@ import "github.com/hmans/beans/internal/beancore"
 // It holds a reference to beancore.Core for data access.
 type Resolver struct {
 	Core *beancore.Core
+}
+
+// ETagMismatchError is returned when an ETag validation fails.
+// This allows callers to distinguish concurrency conflicts from other errors.
+type ETagMismatchError struct {
+	Provided string
+	Current  string
+}
+
+func (e *ETagMismatchError) Error() string {
+	return fmt.Sprintf("etag mismatch: provided %s, current is %s", e.Provided, e.Current)
+}
+
+// ETagRequiredError is returned when require_if_match is enabled and no ETag is provided.
+type ETagRequiredError struct{}
+
+func (e *ETagRequiredError) Error() string {
+	return "if-match etag is required (set require_if_match: false in config to disable)"
+}
+
+// validateETag checks if the provided ifMatch etag matches the bean's current etag.
+// Returns an error if validation fails or if require_if_match is enabled and no etag provided.
+func (r *Resolver) validateETag(b *bean.Bean, ifMatch *string) error {
+	cfg := r.Core.Config()
+	requireIfMatch := cfg != nil && cfg.Beans.RequireIfMatch
+
+	// If require_if_match is enabled and no etag provided, reject
+	if requireIfMatch && (ifMatch == nil || *ifMatch == "") {
+		return &ETagRequiredError{}
+	}
+
+	// If ifMatch provided, validate it
+	if ifMatch != nil && *ifMatch != "" {
+		currentETag := b.ETag()
+		if currentETag != *ifMatch {
+			return &ETagMismatchError{Provided: *ifMatch, Current: currentETag}
+		}
+	}
+
+	return nil
 }

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -33,17 +33,17 @@ type Mutation {
   """
   Set or clear the parent of a bean (validates type hierarchy)
   """
-  setParent(id: ID!, parentId: String): Bean!
+  setParent(id: ID!, parentId: String, ifMatch: String): Bean!
 
   """
   Add a bean to the blocking list
   """
-  addBlocking(id: ID!, targetId: ID!): Bean!
+  addBlocking(id: ID!, targetId: ID!, ifMatch: String): Bean!
 
   """
   Remove a bean from the blocking list
   """
-  removeBlocking(id: ID!, targetId: ID!): Bean!
+  removeBlocking(id: ID!, targetId: ID!, ifMatch: String): Bean!
 }
 
 """
@@ -86,6 +86,8 @@ input UpdateBeanInput {
   tags: [String!]
   "New body content"
   body: String
+  "ETag for optimistic concurrency control (optional)"
+  ifMatch: String
 }
 
 """
@@ -114,6 +116,8 @@ type Bean {
   updatedAt: Time!
   "Markdown body content"
   body: String!
+  "Content hash for optimistic concurrency control"
+  etag: String!
 
   # Direct link fields
   "Parent bean ID (optional, type-restricted)"

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -145,6 +145,11 @@ func (r *mutationResolver) UpdateBean(ctx context.Context, id string, input mode
 		return nil, err
 	}
 
+	// Validate ETag if provided or required
+	if err := r.validateETag(b, input.IfMatch); err != nil {
+		return nil, err
+	}
+
 	// Update fields if provided
 	if input.Title != nil {
 		b.Title = *input.Title
@@ -194,9 +199,14 @@ func (r *mutationResolver) DeleteBean(ctx context.Context, id string) (bool, err
 }
 
 // SetParent is the resolver for the setParent field.
-func (r *mutationResolver) SetParent(ctx context.Context, id string, parentID *string) (*bean.Bean, error) {
+func (r *mutationResolver) SetParent(ctx context.Context, id string, parentID *string, ifMatch *string) (*bean.Bean, error) {
 	b, err := r.Core.Get(id)
 	if err != nil {
+		return nil, err
+	}
+
+	// Validate ETag if provided or required
+	if err := r.validateETag(b, ifMatch); err != nil {
 		return nil, err
 	}
 
@@ -225,9 +235,14 @@ func (r *mutationResolver) SetParent(ctx context.Context, id string, parentID *s
 }
 
 // AddBlocking is the resolver for the addBlocking field.
-func (r *mutationResolver) AddBlocking(ctx context.Context, id string, targetID string) (*bean.Bean, error) {
+func (r *mutationResolver) AddBlocking(ctx context.Context, id string, targetID string, ifMatch *string) (*bean.Bean, error) {
 	b, err := r.Core.Get(id)
 	if err != nil {
+		return nil, err
+	}
+
+	// Validate ETag if provided or required
+	if err := r.validateETag(b, ifMatch); err != nil {
 		return nil, err
 	}
 
@@ -256,9 +271,14 @@ func (r *mutationResolver) AddBlocking(ctx context.Context, id string, targetID 
 }
 
 // RemoveBlocking is the resolver for the removeBlocking field.
-func (r *mutationResolver) RemoveBlocking(ctx context.Context, id string, targetID string) (*bean.Bean, error) {
+func (r *mutationResolver) RemoveBlocking(ctx context.Context, id string, targetID string, ifMatch *string) (*bean.Bean, error) {
 	b, err := r.Core.Get(id)
 	if err != nil {
+		return nil, err
+	}
+
+	// Validate ETag if provided or required
+	if err := r.validateETag(b, ifMatch); err != nil {
 		return nil, err
 	}
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -15,6 +15,7 @@ const (
 	ErrInvalidStatus = "INVALID_STATUS"
 	ErrFileError     = "FILE_ERROR"
 	ErrValidation    = "VALIDATION_ERROR"
+	ErrConflict      = "CONFLICT"
 )
 
 // Response is the standard JSON response envelope.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -357,14 +357,14 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case blockingConfirmedMsg:
 		// Apply all blocking changes via GraphQL mutations
 		for _, targetID := range msg.toAdd {
-			_, err := a.resolver.Mutation().AddBlocking(context.Background(), msg.beanID, targetID)
+			_, err := a.resolver.Mutation().AddBlocking(context.Background(), msg.beanID, targetID, nil)
 			if err != nil {
 				// Continue with other changes even if one fails
 				continue
 			}
 		}
 		for _, targetID := range msg.toRemove {
-			_, err := a.resolver.Mutation().RemoveBlocking(context.Background(), msg.beanID, targetID)
+			_, err := a.resolver.Mutation().RemoveBlocking(context.Background(), msg.beanID, targetID, nil)
 			if err != nil {
 				// Continue with other changes even if one fails
 				continue
@@ -456,7 +456,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			parentID = &msg.parentID
 		}
 		for _, beanID := range msg.beanIDs {
-			_, err := a.resolver.Mutation().SetParent(context.Background(), beanID, parentID)
+			_, err := a.resolver.Mutation().SetParent(context.Background(), beanID, parentID, nil)
 			if err != nil {
 				// Continue with other beans even if one fails
 				continue


### PR DESCRIPTION
## Summary

Adds ETag-based optimistic concurrency control to prevent lost updates when multiple agents work on the same bean concurrently.

Supersedes #57 (this PR extracts just the ETag feature; body modification will be a separate PR).

## Changes

- Add `ETag()` method to Bean using FNV-1a 64-bit hash of rendered content
- Include `etag` field in JSON output and GraphQL schema
- Add `--if-match` flag to `beans update` for optimistic locking
- Add `--etag-only` flag to `beans show` for easy etag extraction
- Add `ifMatch` parameter to GraphQL mutations
- Add typed errors (`ETagMismatchError`, `ETagRequiredError`) with `CONFLICT` code
- Add `require_if_match` config option to enforce ETag usage
- Comprehensive test coverage

## Usage

```bash
# Get etag
ETAG=$(beans show <id> --etag-only)

# Update with concurrency protection
beans update <id> --status completed --if-match "$ETAG"

# On conflict, get clear error with current etag
# Error: etag mismatch (expected abc123, got def456)
```