### PR TITLE
feat: add 'h' key toggle to hide completed/scrapped beans in TUI

### DIFF
--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -83,6 +83,7 @@ func (m helpOverlayModel) View() string {
 	content.WriteString(shortcut("b", "Manage blocking") + "\n")
 	content.WriteString(shortcut("c", "Create new bean") + "\n")
 	content.WriteString(shortcut("e", "Edit in $EDITOR") + "\n")
+	content.WriteString(shortcut("h", "Toggle hide completed") + "\n")
 	content.WriteString(shortcut("p", "Set parent") + "\n")
 	content.WriteString(shortcut("P", "Change priority") + "\n")
 	content.WriteString(shortcut("s", "Change status") + "\n")

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
@@ -115,7 +116,8 @@ type listModel struct {
 	idColWidth int                  // ID column width (accounts for tree depth)
 
 	// Active filters
-	tagFilter string // if set, only show beans with this tag
+	tagFilter     string // if set, only show beans with this tag
+	hideCompleted bool   // if true, hide completed and scrapped beans
 
 	// Multi-select state
 	selectedBeans map[string]bool // IDs of beans marked for multi-edit
@@ -167,10 +169,16 @@ func (m listModel) Init() tea.Cmd {
 }
 
 func (m listModel) loadBeans() tea.Msg {
-	// Build filter if tag filter is set
+	// Build filter based on active filters
 	var filter *model.BeanFilter
-	if m.tagFilter != "" {
-		filter = &model.BeanFilter{Tags: []string{m.tagFilter}}
+	if m.tagFilter != "" || m.hideCompleted {
+		filter = &model.BeanFilter{}
+		if m.tagFilter != "" {
+			filter.Tags = []string{m.tagFilter}
+		}
+		if m.hideCompleted {
+			filter.ExcludeStatus = []string{"completed", "scrapped"}
+		}
 	}
 
 	// Query filtered beans
@@ -214,6 +222,11 @@ func (m listModel) loadBeans() tea.Msg {
 // setTagFilter sets the tag filter
 func (m *listModel) setTagFilter(tag string) {
 	m.tagFilter = tag
+}
+
+// toggleHideCompleted toggles the hideCompleted filter
+func (m *listModel) toggleHideCompleted() {
+	m.hideCompleted = !m.hideCompleted
 }
 
 // clearFilter clears all active filters
@@ -417,6 +430,10 @@ func (m listModel) Update(msg tea.Msg) (listModel, tea.Cmd) {
 						}
 					}
 				}
+			case "h":
+				// Toggle hide completed/scrapped beans
+				m.toggleHideCompleted()
+				return m, m.loadBeans
 			case "y":
 				// Copy bean ID(s) to clipboard
 				if len(m.selectedBeans) > 0 {
@@ -490,9 +507,16 @@ func (m listModel) View() string {
 		return "Loading..."
 	}
 
-	// Update title based on active filter
+	// Update title based on active filters
+	var titleParts []string
 	if m.tagFilter != "" {
-		m.list.Title = fmt.Sprintf("Beans [tag: %s]", m.tagFilter)
+		titleParts = append(titleParts, fmt.Sprintf("tag: %s", m.tagFilter))
+	}
+	if m.hideCompleted {
+		titleParts = append(titleParts, "hiding completed")
+	}
+	if len(titleParts) > 0 {
+		m.list.Title = fmt.Sprintf("Beans [%s]", strings.Join(titleParts, "] ["))
 	} else {
 		m.list.Title = "Beans"
 	}
@@ -592,13 +616,19 @@ func (m listModel) ViewConstrained(width, height int) string {
 	m.cols = ui.CalculateResponsiveColumns(width, m.hasTags)
 	m.updateDelegate()
 
-	// Update title based on active filter
+	// Update title based on active filters
+	var titleParts []string
 	if m.tagFilter != "" {
-		m.list.Title = fmt.Sprintf("Beans [tag: %s]", m.tagFilter)
+		titleParts = append(titleParts, fmt.Sprintf("tag: %s", m.tagFilter))
+	}
+	if m.hideCompleted {
+		titleParts = append(titleParts, "hiding completed")
+	}
+	if len(titleParts) > 0 {
+		m.list.Title = fmt.Sprintf("Beans [%s]", strings.Join(titleParts, "] ["))
 	} else {
 		m.list.Title = "Beans"
 	}
 
 	return m.viewContent(innerHeight)
 }
-


### PR DESCRIPTION
### Summary

Adds a toggle key (`h`) in the TUI to hide beans with `completed` or `scrapped` status, making it easier to focus on active work while keeping finished beans accessible when needed.

### Motivation

When working with projects that accumulate many completed/scrapped beans, the TUI list can become cluttered with finished work. While archived beans provide valuable project memory and context, users often want to focus only on active work during day-to-day usage.

This change provides a simple toggle to hide finished beans without removing the ability to see them when context is needed.

### Changes

**Core Implementation:**
- Added `hideCompleted` boolean field to `listModel` to track toggle state
- Modified `loadBeans()` to apply GraphQL `ExcludeStatus` filter when toggle is active
- Implemented `toggleHideCompleted()` method to flip the filter state
- Added `h` key binding handler in list view

**User Experience:**
- Press `h` in list view to toggle hiding of completed/scrapped beans
- Title dynamically updates to reflect active filters:
  - Default: `"Beans"`
  - With toggle: `"Beans [hiding completed]"`
  - With both filters: `"Beans [tag: bug] [hiding completed]"`
- Added `h` shortcut to help overlay (press `?` to view)
- Updated both `View()` and `ViewConstrained()` for consistency in two-column mode

**Filter Behavior:**
- Hide-completed filter works independently from tag filter (both can be active)
- Default state shows all beans (no behavior change for existing users)
- Press `esc` to clear tag filter only; `h` controls completed/scrapped visibility separately
- Uses existing GraphQL `ExcludeStatus` filter for efficient server-side filtering

### Technical Details

**Filtering Approach:**
The implementation leverages the existing GraphQL `BeanFilter.ExcludeStatus` field to filter at query time, ensuring efficient operation even with large bean sets. The filter is applied in `loadBeans()` alongside any active tag filters.

**Status vs Archive Directory:**
This toggle filters by bean **status** (`completed`/`scrapped`), not by archive directory location. This is intentional:
- Status represents semantic completion state (what's done)
- Archive directory is organizational (tidiness)
- Beans in `archive/` are always loaded per project design (see commit d7b01db)
- Most archived beans are completed/scrapped anyway, so toggle handles the primary use case

### Testing

- ✅ All existing tests pass (11/11 TUI tests)
- ✅ No compilation errors or vet warnings
- ✅ GraphQL `ExcludeStatus` filter verified working correctly
- ✅ Tested with 53 total beans (25 completed/scrapped)
- ✅ Filter correctly excludes completed/scrapped beans
- ✅ Builds successfully
- ✅ Works in both single-column and two-column preview modes

### Checklist

- [x] Code follows project conventions
- [x] All tests pass
- [x] No breaking changes
- [x] Feature works in both single and two-column modes
- [x] Help overlay updated with new shortcut
- [x] Default behavior unchanged (shows all beans)