### PR TITLE
feat: add 'H' toggle to hide completed/scrapped beans in TUI

### DIFF
--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -83,6 +83,7 @@ func (m helpOverlayModel) View() string {
 	content.WriteString(shortcut("b", "Manage blocking") + "\n")
 	content.WriteString(shortcut("c", "Create new bean") + "\n")
 	content.WriteString(shortcut("e", "Edit in $EDITOR") + "\n")
+	content.WriteString(shortcut("H", "Toggle hide completed") + "\n")
 	content.WriteString(shortcut("p", "Set parent") + "\n")
 	content.WriteString(shortcut("P", "Change priority") + "\n")
 	content.WriteString(shortcut("s", "Change status") + "\n")


### PR DESCRIPTION
Refs: beans-k5mz

## Summary

- Adds 'H' (shift+h) key binding to toggle visibility of completed/scrapped beans in the TUI
- Uses existing GraphQL ExcludeStatus filter
- Works independently from tag filter - both can be active simultaneously
- List title shows active filters: `[hiding completed]`
- Changed from 'h' to 'H' to avoid conflict with vim navigation keys

## Implementation Details

- Added `hideCompleted` boolean field to `listModel` struct
- Modified `loadBeans()` to use GraphQL `ExcludeStatus` filter when toggle is active
- Added `toggleHideCompleted()` method to flip the state
- Implemented 'H' key binding handler to toggle the filter
- Updated list title to show both tag and hide-completed filters when active
- Added 'H' shortcut to help overlay (? key)
- Updated both `View()` and `ViewConstrained()` methods for consistency

## Testing

- Verified GraphQL ExcludeStatus filter correctly excludes completed/scrapped beans
- Tested toggle functionality in TUI
- Build successful with no compilation errors