### PR TITLE
fix: add trailing newline to bean files

### DIFF
--- a/internal/bean/bean.go
+++ b/internal/bean/bean.go
@@ -153,6 +153,9 @@ func Parse(r io.Reader) (*Bean, error) {
 		return nil, fmt.Errorf("parsing front matter: %w", err)
 	}
 
+	// Trim trailing newline from body (POSIX files end with newline, but it's not part of content)
+	bodyStr := strings.TrimSuffix(string(body), "\n")
+
 	return &Bean{
 		Title:     fm.Title,
 		Status:    fm.Status,
@@ -161,7 +164,7 @@ func Parse(r io.Reader) (*Bean, error) {
 		Tags:      fm.Tags,
 		CreatedAt: fm.CreatedAt,
 		UpdatedAt: fm.UpdatedAt,
-		Body:      string(body),
+		Body:      bodyStr,
 		Parent:    fm.Parent,
 		Blocking:  fm.Blocking,
 	}, nil
@@ -214,6 +217,13 @@ func (b *Bean) Render() ([]byte, error) {
 			buf.WriteString("\n")
 		}
 		buf.WriteString(b.Body)
+		// Ensure trailing newline if body doesn't end with one
+		if !strings.HasSuffix(b.Body, "\n") {
+			buf.WriteString("\n")
+		}
+	} else {
+		// Even without body, add trailing newline for POSIX compliance
+		buf.WriteString("\n")
 	}
 
 	return buf.Bytes(), nil

--- a/internal/bean/bean_test.go
+++ b/internal/bean/bean_test.go
@@ -1217,6 +1217,49 @@ func TestRenderWithIDCommentRoundtrip(t *testing.T) {
 	}
 }
 
+func TestRenderTrailingNewline(t *testing.T) {
+	tests := []struct {
+		name string
+		bean *Bean
+	}{
+		{
+			name: "with body",
+			bean: &Bean{
+				Title:  "Test Bean",
+				Status: "todo",
+				Body:   "Some content without trailing newline",
+			},
+		},
+		{
+			name: "with body ending in newline",
+			bean: &Bean{
+				Title:  "Test Bean",
+				Status: "todo",
+				Body:   "Some content with trailing newline\n",
+			},
+		},
+		{
+			name: "without body",
+			bean: &Bean{
+				Title:  "Test Bean",
+				Status: "todo",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rendered, err := tt.bean.Render()
+			if err != nil {
+				t.Fatalf("Render error: %v", err)
+			}
+			if !strings.HasSuffix(string(rendered), "\n") {
+				t.Errorf("rendered output should end with newline\ngot: %q", rendered)
+			}
+		})
+	}
+}
+
 func TestETag(t *testing.T) {
 	t.Run("consistent hash", func(t *testing.T) {
 		b := &Bean{


### PR DESCRIPTION
Bean files don't end with a trailing newline, which violates POSIX convention for text files and can cause issues with some tools/editors/ide and causes many pre-commit hooks to raise errors.

## Changes
- `Render()` now ensures files end with newline
- `Parse()` trims trailing newline from body to maintain roundtrip consistency
- Added `TestRenderTrailingNewline` test

## Testing
All tests pass locally.
Also tested manually.

---

BTW, great project, thanks.