### PR TITLE
feat: add custom prime template config option

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/hmans/beans/internal/beancore"
 	"github.com/hmans/beans/internal/config"
 	"github.com/hmans/beans/internal/ui"
+	"github.com/spf13/cobra"
 )
 
 var (
@@ -95,6 +95,18 @@ Note: Cycles cannot be auto-fixed and require manual intervention.`,
 			}
 			if typeColorErrors == 0 {
 				fmt.Printf("  %s All type colors valid\n", ui.Success.Render("✓"))
+			}
+		}
+
+		// 5. Check custom prime template exists (if configured)
+		if cfg.Templates.Prime != "" {
+			primePath := cfg.ResolvePrimeTemplatePath()
+			if _, err := os.Stat(primePath); os.IsNotExist(err) {
+				configErrors = append(configErrors, fmt.Sprintf("custom prime template not found: %s", primePath))
+			} else if err != nil {
+				configErrors = append(configErrors, fmt.Sprintf("cannot access custom prime template: %s: %v", primePath, err))
+			} else if !checkJSON {
+				fmt.Printf("  %s Custom prime template exists (%s)\n", ui.Success.Render("✓"), cfg.Templates.Prime)
 			}
 		}
 

--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -1,12 +1,15 @@
 package cmd
 
 import (
+	"bytes"
 	_ "embed"
+	"fmt"
+	"io"
 	"os"
 	"text/template"
 
-	"github.com/spf13/cobra"
 	"github.com/hmans/beans/internal/config"
+	"github.com/spf13/cobra"
 )
 
 //go:embed prompt.tmpl
@@ -18,6 +21,62 @@ type promptData struct {
 	Types         []config.TypeConfig
 	Statuses      []config.StatusConfig
 	Priorities    []config.PriorityConfig
+	OriginalPrime string
+}
+
+// primeResult holds the output of renderPrime for inspection.
+type primeResult struct {
+	Output  string // The rendered prime output
+	Warning string // Non-empty if a fallback occurred
+}
+
+// renderPrime renders the prime output using the given config.
+// If a custom template is configured but cannot be loaded or parsed,
+// it falls back to the built-in template and sets a warning.
+func renderPrime(primeCfg *config.Config, data promptData) (*primeResult, error) {
+	builtinTmpl, err := template.New("prompt").Parse(agentPromptTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	primePath := primeCfg.ResolvePrimeTemplatePath()
+	if primePath == "" {
+		var buf bytes.Buffer
+		if err := builtinTmpl.Execute(&buf, data); err != nil {
+			return nil, err
+		}
+		return &primeResult{Output: buf.String()}, nil
+	}
+
+	// Custom template configured - render built-in to string first
+	var builtinBuf bytes.Buffer
+	if err := builtinTmpl.Execute(&builtinBuf, data); err != nil {
+		return nil, fmt.Errorf("rendering built-in prime template: %w", err)
+	}
+	data.OriginalPrime = builtinBuf.String()
+
+	// Read and parse the custom template
+	customTmplContent, err := os.ReadFile(primePath)
+	if err != nil {
+		return &primeResult{
+			Output:  builtinBuf.String(),
+			Warning: fmt.Sprintf("custom prime template not found: %s (falling back to built-in)", primePath),
+		}, nil
+	}
+
+	customTmpl, err := template.New("custom-prompt").Parse(string(customTmplContent))
+	if err != nil {
+		return &primeResult{
+			Output:  builtinBuf.String(),
+			Warning: fmt.Sprintf("parsing custom prime template: %v (falling back to built-in)", err),
+		}, nil
+	}
+
+	var customBuf bytes.Buffer
+	if err := customTmpl.Execute(&customBuf, data); err != nil {
+		return nil, fmt.Errorf("executing custom prime template: %w", err)
+	}
+	return &primeResult{Output: customBuf.String()}, nil
 }
 
 var primeCmd = &cobra.Command{
@@ -28,6 +87,7 @@ var primeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// If no explicit path given, check if a beans project exists by searching
 		// upward for a .beans.yml config file
+		var primeCfg *config.Config
 		if beansPath == "" && configPath == "" {
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -38,11 +98,25 @@ var primeCmd = &cobra.Command{
 				// No config file found - silently exit
 				return nil
 			}
-		}
-
-		tmpl, err := template.New("prompt").Parse(agentPromptTemplate)
-		if err != nil {
-			return err
+			primeCfg, err = config.Load(configFile)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
+		} else if configPath != "" {
+			var err error
+			primeCfg, err = config.Load(configPath)
+			if err != nil {
+				return fmt.Errorf("loading config from %s: %w", configPath, err)
+			}
+		} else {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting current directory: %w", err)
+			}
+			primeCfg, err = config.LoadFromDirectory(cwd)
+			if err != nil {
+				return fmt.Errorf("loading config: %w", err)
+			}
 		}
 
 		data := promptData{
@@ -52,7 +126,17 @@ var primeCmd = &cobra.Command{
 			Priorities:    config.DefaultPriorities,
 		}
 
-		return tmpl.Execute(os.Stdout, data)
+		result, err := renderPrime(primeCfg, data)
+		if err != nil {
+			return err
+		}
+
+		if result.Warning != "" {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", result.Warning)
+		}
+
+		_, err = io.WriteString(os.Stdout, result.Output)
+		return err
 	},
 }
 

--- a/cmd/prime_test.go
+++ b/cmd/prime_test.go
@@ -1,0 +1,261 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hmans/beans/internal/config"
+)
+
+func testPromptData() promptData {
+	return promptData{
+		GraphQLSchema: "type Query { bean(id: ID!): Bean }",
+		Types:         config.DefaultTypes,
+		Statuses:      config.DefaultStatuses,
+		Priorities:    config.DefaultPriorities,
+	}
+}
+
+func TestRenderPrime_BuiltinTemplate(t *testing.T) {
+	cfg := config.Default()
+	cfg.SetConfigDir(t.TempDir())
+
+	result, err := renderPrime(cfg, testPromptData())
+	if err != nil {
+		t.Fatalf("renderPrime() error = %v", err)
+	}
+
+	if result.Warning != "" {
+		t.Errorf("unexpected warning: %s", result.Warning)
+	}
+	if !strings.Contains(result.Output, "Beans Usage Guide") {
+		t.Error("built-in output should contain 'Beans Usage Guide'")
+	}
+	// All types should be rendered
+	for _, typ := range config.DefaultTypes {
+		if !strings.Contains(result.Output, typ.Name) {
+			t.Errorf("built-in output should contain type %q", typ.Name)
+		}
+	}
+	// All statuses should be rendered
+	for _, status := range config.DefaultStatuses {
+		if !strings.Contains(result.Output, status.Name) {
+			t.Errorf("built-in output should contain status %q", status.Name)
+		}
+	}
+	// All priorities should be rendered
+	for _, priority := range config.DefaultPriorities {
+		if !strings.Contains(result.Output, priority.Name) {
+			t.Errorf("built-in output should contain priority %q", priority.Name)
+		}
+	}
+}
+
+func TestRenderPrime_CustomTemplate(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	customContent := `# Custom Prime
+{{range .Types}}- {{.Name}}
+{{end}}
+Schema: {{.GraphQLSchema}}
+Original: {{.OriginalPrime}}`
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "prime.tmpl"), []byte(customContent), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	cfg := &config.Config{
+		Templates: config.TemplatesConfig{Prime: "prime.tmpl"},
+	}
+	cfg.SetConfigDir(tmpDir)
+
+	result, err := renderPrime(cfg, testPromptData())
+	if err != nil {
+		t.Fatalf("renderPrime() error = %v", err)
+	}
+
+	if result.Warning != "" {
+		t.Errorf("unexpected warning: %s", result.Warning)
+	}
+	if !strings.Contains(result.Output, "Custom Prime") {
+		t.Error("output should contain custom header")
+	}
+	// Types should be rendered via the custom template
+	for _, typ := range config.DefaultTypes {
+		if !strings.Contains(result.Output, typ.Name) {
+			t.Errorf("output should contain type %q", typ.Name)
+		}
+	}
+	// GraphQL schema should be accessible
+	if !strings.Contains(result.Output, "type Query") {
+		t.Error("output should contain GraphQL schema")
+	}
+	// OriginalPrime should contain the built-in output
+	if !strings.Contains(result.Output, "Beans Usage Guide") {
+		t.Error("OriginalPrime in output should contain built-in prime content")
+	}
+}
+
+func TestRenderPrime_CustomTemplateWithOriginalPrime(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	customContent := `# Before
+{{.OriginalPrime}}
+# After`
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "prime.tmpl"), []byte(customContent), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	cfg := &config.Config{
+		Templates: config.TemplatesConfig{Prime: "prime.tmpl"},
+	}
+	cfg.SetConfigDir(tmpDir)
+
+	result, err := renderPrime(cfg, testPromptData())
+	if err != nil {
+		t.Fatalf("renderPrime() error = %v", err)
+	}
+
+	if result.Warning != "" {
+		t.Errorf("unexpected warning: %s", result.Warning)
+	}
+
+	// Verify ordering: custom header, then original, then custom footer
+	beforeIdx := strings.Index(result.Output, "# Before")
+	usageIdx := strings.Index(result.Output, "Beans Usage Guide")
+	afterIdx := strings.Index(result.Output, "# After")
+
+	if beforeIdx == -1 || usageIdx == -1 || afterIdx == -1 {
+		t.Fatalf("missing expected sections in output:\n%s", result.Output)
+	}
+	if beforeIdx >= usageIdx {
+		t.Error("'# Before' should appear before 'Beans Usage Guide'")
+	}
+	if usageIdx >= afterIdx {
+		t.Error("'Beans Usage Guide' should appear before '# After'")
+	}
+}
+
+func TestRenderPrime_FallbackOnMissingTemplate(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	cfg := &config.Config{
+		Templates: config.TemplatesConfig{Prime: "nonexistent.tmpl"},
+	}
+	cfg.SetConfigDir(tmpDir)
+
+	result, err := renderPrime(cfg, testPromptData())
+	if err != nil {
+		t.Fatalf("renderPrime() error = %v, expected fallback", err)
+	}
+
+	// Should have a warning
+	if result.Warning == "" {
+		t.Error("expected warning about missing template")
+	}
+	if !strings.Contains(result.Warning, "nonexistent.tmpl") {
+		t.Errorf("warning should mention the missing file, got: %s", result.Warning)
+	}
+	if !strings.Contains(result.Warning, "falling back") {
+		t.Errorf("warning should mention fallback, got: %s", result.Warning)
+	}
+
+	// Should still output the built-in prime
+	if !strings.Contains(result.Output, "Beans Usage Guide") {
+		t.Error("fallback output should contain built-in prime content")
+	}
+}
+
+func TestRenderPrime_FallbackOnBadTemplateSyntax(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	badContent := `{{.Unclosed`
+	if err := os.WriteFile(filepath.Join(tmpDir, "bad.tmpl"), []byte(badContent), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	cfg := &config.Config{
+		Templates: config.TemplatesConfig{Prime: "bad.tmpl"},
+	}
+	cfg.SetConfigDir(tmpDir)
+
+	result, err := renderPrime(cfg, testPromptData())
+	if err != nil {
+		t.Fatalf("renderPrime() error = %v, expected fallback", err)
+	}
+
+	// Should have a warning about parse error
+	if result.Warning == "" {
+		t.Error("expected warning about parse error")
+	}
+	if !strings.Contains(result.Warning, "parsing") {
+		t.Errorf("warning should mention parsing, got: %s", result.Warning)
+	}
+	if !strings.Contains(result.Warning, "falling back") {
+		t.Errorf("warning should mention fallback, got: %s", result.Warning)
+	}
+
+	// Should still output the built-in prime
+	if !strings.Contains(result.Output, "Beans Usage Guide") {
+		t.Error("fallback output should contain built-in prime content")
+	}
+}
+
+func TestRenderPrime_NoCustomTemplateConfigured(t *testing.T) {
+	cfg := config.Default()
+	cfg.SetConfigDir(t.TempDir())
+
+	// Verify that Templates.Prime is empty
+	if cfg.Templates.Prime != "" {
+		t.Fatalf("expected empty Templates.Prime in default config, got %q", cfg.Templates.Prime)
+	}
+
+	result, err := renderPrime(cfg, testPromptData())
+	if err != nil {
+		t.Fatalf("renderPrime() error = %v", err)
+	}
+
+	if result.Warning != "" {
+		t.Errorf("unexpected warning: %s", result.Warning)
+	}
+	if !strings.Contains(result.Output, "Beans Usage Guide") {
+		t.Error("output should contain built-in prime content")
+	}
+}
+
+func TestRenderPrime_CustomTemplateWithoutOriginalPrime(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Custom template that completely replaces the built-in (doesn't use OriginalPrime)
+	customContent := `# Fully Custom
+This project uses beans.
+Types: {{range .Types}}{{.Name}} {{end}}`
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "prime.tmpl"), []byte(customContent), 0644); err != nil {
+		t.Fatalf("WriteFile error = %v", err)
+	}
+
+	cfg := &config.Config{
+		Templates: config.TemplatesConfig{Prime: "prime.tmpl"},
+	}
+	cfg.SetConfigDir(tmpDir)
+
+	result, err := renderPrime(cfg, testPromptData())
+	if err != nil {
+		t.Fatalf("renderPrime() error = %v", err)
+	}
+
+	if result.Warning != "" {
+		t.Errorf("unexpected warning: %s", result.Warning)
+	}
+	if !strings.Contains(result.Output, "Fully Custom") {
+		t.Error("output should contain custom content")
+	}
+	// Should NOT contain built-in content since OriginalPrime wasn't used
+	if strings.Contains(result.Output, "EXTREMELY_IMPORTANT") {
+		t.Error("output should not contain built-in prime content when OriginalPrime is not referenced")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,10 +69,17 @@ type PriorityConfig struct {
 	Description string `yaml:"description,omitempty"`
 }
 
+// TemplatesConfig defines custom template overrides.
+type TemplatesConfig struct {
+	// Prime is the path to a custom prime template file (relative to config file location)
+	Prime string `yaml:"prime,omitempty"`
+}
+
 // Config holds the beans configuration.
 // Note: Statuses are no longer stored in config - they are hardcoded like types.
 type Config struct {
-	Beans BeansConfig `yaml:"beans"`
+	Beans     BeansConfig     `yaml:"beans"`
+	Templates TemplatesConfig `yaml:"templates,omitempty"`
 
 	// configDir is the directory containing the config file (not serialized)
 	// Used to resolve relative paths
@@ -198,6 +205,22 @@ func (c *Config) ResolveBeansPath() string {
 		return filepath.Join(cwd, c.Beans.Path)
 	}
 	return filepath.Join(c.configDir, c.Beans.Path)
+}
+
+// ResolvePrimeTemplatePath returns the absolute path to the custom prime template file,
+// or an empty string if no custom prime template is configured.
+func (c *Config) ResolvePrimeTemplatePath() string {
+	if c.Templates.Prime == "" {
+		return ""
+	}
+	if filepath.IsAbs(c.Templates.Prime) {
+		return c.Templates.Prime
+	}
+	if c.configDir == "" {
+		cwd, _ := os.Getwd()
+		return filepath.Join(cwd, c.Templates.Prime)
+	}
+	return filepath.Join(c.configDir, c.Templates.Prime)
 }
 
 // ConfigDir returns the directory containing the config file.


### PR DESCRIPTION
Relates to #65

## Summary

- Add `templates.prime` config option to `.beans.yml` for overriding the built-in prime document with a custom Go template file
- Custom templates have access to all built-in template variables plus `{{.OriginalPrime}}` (the fully-rendered built-in prime output)
- Graceful fallback: when a configured template file is missing or has parse errors, `beans prime` warns on stderr and outputs the built-in prime instead of failing
- `beans check` validates that the custom prime template file exists when configured

This allows users to add project-specific or agent-specific instructions (like those suggested in #65) without forking the built-in prime template. Users can wrap the original prime with their own additions via `{{.OriginalPrime}}`, or replace it entirely.

## Configuration

```yaml
beans:
    path: .beans
    prefix: beans-

templates:
    prime: extras/custom-prime.tmpl  # path relative to .beans.yml
```

## Template Variables

Custom templates have access to:

- `{{.GraphQLSchema}}` - The GraphQL schema
- `{{.Types}}` - Type configs (name, color, description)
- `{{.Statuses}}` - Status configs
- `{{.Priorities}}` - Priority configs
- `{{.OriginalPrime}}` - The fully-rendered built-in prime output

## Example

```
# Project-Specific Instructions

Custom guidance for this project...

{{.OriginalPrime}}

## Additional Context

More project-specific notes...
```

## Changes

- `internal/config/config.go`: Add `TemplatesConfig` struct, `Templates` field on `Config`, `ResolvePrimeTemplatePath()` method
- `cmd/prime.go`: Extract `renderPrime()` function, load config, handle custom template with fallback
- `cmd/check.go`: Validate custom prime template file exists
- `cmd/prime_test.go`: New test file covering rendering, fallback, all template variables
- `internal/config/config_test.go`: Tests for path resolution, config loading, save/load round-trip

## Design Notes

The `templates` section is a new top-level config key (separate from `beans`) to allow future extensibility:

```yaml
# Future: agent-specific prime templates
templates:
    prime:
        default: extras/custom-prime.tmpl
        claude: extras/claude-specific.tmpl
        opencode: extras/opencode-specific.tmpl
```