### PR TITLE
feat: add BEANS_PATH environment variable support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
 	"github.com/hmans/beans/internal/beancore"
 	"github.com/hmans/beans/internal/config"
+	"github.com/spf13/cobra"
 )
 
 var core *beancore.Core
@@ -48,21 +48,9 @@ a full view of your project.`,
 		}
 
 		// Determine beans directory
-		var root string
-		if beansPath != "" {
-			// Use explicit beans path (overrides config)
-			root = beansPath
-			// Verify it exists
-			if info, statErr := os.Stat(root); statErr != nil || !info.IsDir() {
-				return fmt.Errorf("beans path does not exist or is not a directory: %s", root)
-			}
-		} else {
-			// Use path from config
-			root = cfg.ResolveBeansPath()
-			// Verify it exists
-			if info, statErr := os.Stat(root); statErr != nil || !info.IsDir() {
-				return fmt.Errorf("no .beans directory found at %s (run 'beans init' to create one)", root)
-			}
+		root, err := resolveBeansPath(beansPath, cfg)
+		if err != nil {
+			return err
 		}
 
 		core = beancore.New(root, cfg)
@@ -75,8 +63,34 @@ a full view of your project.`,
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&beansPath, "beans-path", "", "Path to data directory (overrides config)")
+	rootCmd.PersistentFlags().StringVar(&beansPath, "beans-path", "", "Path to data directory (overrides config and BEANS_PATH env var)")
 	rootCmd.PersistentFlags().StringVar(&configPath, "config", "", "Path to config file (default: searches upward for .beans.yml)")
+}
+
+// resolveBeansPath determines the beans data directory path.
+// Precedence: --beans-path flag > BEANS_PATH env var > config.
+func resolveBeansPath(flagPath string, c *config.Config) (string, error) {
+	var root string
+	if flagPath != "" {
+		// Use explicit beans path flag (highest priority)
+		root = flagPath
+	} else if envPath := os.Getenv("BEANS_PATH"); envPath != "" {
+		// Use environment variable (medium priority)
+		root = envPath
+	} else {
+		// Use path from config (lowest priority)
+		root = c.ResolveBeansPath()
+	}
+
+	// Verify it exists
+	if info, statErr := os.Stat(root); statErr != nil || !info.IsDir() {
+		if flagPath != "" || os.Getenv("BEANS_PATH") != "" {
+			return "", fmt.Errorf("beans path does not exist or is not a directory: %s", root)
+		}
+		return "", fmt.Errorf("no .beans directory found at %s (run 'beans init' to create one)", root)
+	}
+
+	return root, nil
 }
 
 func Execute() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hmans/beans/internal/config"
+)
+
+func TestResolveBeansPath(t *testing.T) {
+	// Create a valid beans directory for tests that need one
+	tmpDir := t.TempDir()
+	validBeansDir := filepath.Join(tmpDir, ".beans")
+	if err := os.MkdirAll(validBeansDir, 0755); err != nil {
+		t.Fatalf("failed to create test .beans dir: %v", err)
+	}
+
+	altBeansDir := filepath.Join(tmpDir, "alt-beans")
+	if err := os.MkdirAll(altBeansDir, 0755); err != nil {
+		t.Fatalf("failed to create alt beans dir: %v", err)
+	}
+
+	// Config that points to the valid beans dir
+	cfg := config.Default()
+	cfg.SetConfigDir(tmpDir)
+
+	t.Run("flag takes highest precedence", func(t *testing.T) {
+		t.Setenv("BEANS_PATH", altBeansDir)
+
+		got, err := resolveBeansPath(validBeansDir, cfg)
+		if err != nil {
+			t.Fatalf("resolveBeansPath() error = %v", err)
+		}
+		if got != validBeansDir {
+			t.Errorf("expected flag path %q, got %q", validBeansDir, got)
+		}
+	})
+
+	t.Run("flag overrides env var", func(t *testing.T) {
+		t.Setenv("BEANS_PATH", "/nonexistent/should/not/be/used")
+
+		got, err := resolveBeansPath(validBeansDir, cfg)
+		if err != nil {
+			t.Fatalf("resolveBeansPath() error = %v", err)
+		}
+		if got != validBeansDir {
+			t.Errorf("expected flag path %q, got %q", validBeansDir, got)
+		}
+	})
+
+	t.Run("env var used when flag is empty", func(t *testing.T) {
+		t.Setenv("BEANS_PATH", altBeansDir)
+
+		got, err := resolveBeansPath("", cfg)
+		if err != nil {
+			t.Fatalf("resolveBeansPath() error = %v", err)
+		}
+		if got != altBeansDir {
+			t.Errorf("expected env var path %q, got %q", altBeansDir, got)
+		}
+	})
+
+	t.Run("config used when flag and env var are empty", func(t *testing.T) {
+		t.Setenv("BEANS_PATH", "")
+
+		got, err := resolveBeansPath("", cfg)
+		if err != nil {
+			t.Fatalf("resolveBeansPath() error = %v", err)
+		}
+		expected := cfg.ResolveBeansPath()
+		if got != expected {
+			t.Errorf("expected config path %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("invalid flag path returns error", func(t *testing.T) {
+		_, err := resolveBeansPath("/nonexistent/path", cfg)
+		if err == nil {
+			t.Fatal("expected error for invalid flag path, got nil")
+		}
+		if !strings.Contains(err.Error(), "does not exist or is not a directory") {
+			t.Errorf("expected 'does not exist' error, got %q", err.Error())
+		}
+	})
+
+	t.Run("invalid env var path returns error", func(t *testing.T) {
+		t.Setenv("BEANS_PATH", "/nonexistent/env/path")
+
+		_, err := resolveBeansPath("", cfg)
+		if err == nil {
+			t.Fatal("expected error for invalid env var path, got nil")
+		}
+		if !strings.Contains(err.Error(), "does not exist or is not a directory") {
+			t.Errorf("expected 'does not exist' error, got %q", err.Error())
+		}
+	})
+
+	t.Run("invalid config path returns init suggestion", func(t *testing.T) {
+		t.Setenv("BEANS_PATH", "")
+
+		// Config pointing to a nonexistent directory
+		badCfg := config.Default()
+		badCfg.SetConfigDir("/nonexistent/config/dir")
+
+		_, err := resolveBeansPath("", badCfg)
+		if err == nil {
+			t.Fatal("expected error for invalid config path, got nil")
+		}
+		if !strings.Contains(err.Error(), "beans init") {
+			t.Errorf("expected error to suggest 'beans init', got %q", err.Error())
+		}
+	})
+
+	t.Run("file path rejected as not a directory", func(t *testing.T) {
+		// Create a regular file (not a directory)
+		filePath := filepath.Join(tmpDir, "not-a-dir")
+		if err := os.WriteFile(filePath, []byte("hello"), 0644); err != nil {
+			t.Fatalf("failed to create test file: %v", err)
+		}
+
+		_, err := resolveBeansPath(filePath, cfg)
+		if err == nil {
+			t.Fatal("expected error for file path (not directory), got nil")
+		}
+		if !strings.Contains(err.Error(), "does not exist or is not a directory") {
+			t.Errorf("expected 'does not exist' error, got %q", err.Error())
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds `BEANS_PATH` environment variable as an alternative to the `--beans-path` CLI flag for specifying the beans data directory.

## Motivation

When using beans with git worktrees, it's often desirable to have agents directly use the base checkout's beans directory as a single source of truth across all worktrees.

**Why not use existing approaches?**

- **`--beans-path` flag** - Requires agents to include the flag on every single command invocation, which is error-prone and easy to forget
- **Modifying `.beans.yml` in worktrees** - Creates unwanted modifications that might accidentally get committed or cause merge conflicts

**Why an environment variable?**

An environment variable is easy to set once, transparent across all beans commands, safe from accidental commits, and follows standard patterns for environment-specific configuration.

## Changes

### Path Resolution Precedence

The beans path is now resolved in this order:
1. **`--beans-path` flag** (highest priority) - Explicit user override
2. **`BEANS_PATH` env var** (medium priority) - Session/environment setting
3. **Config file** (lowest priority) - Default behavior

### Implementation

**Extracted `resolveBeansPath()` function** (`cmd/root.go`):
- Centralizes path resolution logic into a testable function
- Checks `os.Getenv("BEANS_PATH")` when flag is empty
- Context-aware error messages (explicit path vs config fallback)

**Updated flag help text**:
- `"Path to data directory (overrides config and BEANS_PATH env var)"`

### Tests

8 test cases in `cmd/root_test.go`:

| Test | Verifies |
|------|----------|
| `flag_takes_highest_precedence` | Flag wins over both env var and config |
| `flag_overrides_env_var` | Flag used even when `BEANS_PATH` is set to invalid path |
| `env_var_used_when_flag_is_empty` | `BEANS_PATH` is picked up when no flag given |
| `config_used_when_flag_and_env_var_are_empty` | Falls through to config when neither is set |
| `invalid_flag_path_returns_error` | Error: "does not exist or is not a directory" |
| `invalid_env_var_path_returns_error` | Same error for bad env var path |
| `invalid_config_path_returns_init_suggestion` | Suggests `beans init` for config fallback |
| `file_path_rejected_as_not_a_directory` | Regular file (not dir) is rejected |

## Usage

```bash
# Set once for the session — all beans commands use it
export BEANS_PATH=/path/to/base-checkout/.beans
beans list
beans create "New task" -t task

# Flag still takes precedence when needed
BEANS_PATH=/default/path beans list --beans-path /override/path
```