### PR TITLE
feat: add transitive blocked status through parent hierarchy (Refs: beans-8mhc)

### DIFF
--- a/internal/graph/generated.go
+++ b/internal/graph/generated.go
@@ -3842,7 +3842,7 @@ func (ec *executionContext) unmarshalInputBeanFilter(ctx context.Context, obj an
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"search", "status", "excludeStatus", "type", "excludeType", "priority", "excludePriority", "tags", "excludeTags", "hasParent", "parentId", "hasBlocking", "blockingId", "isBlocked", "hasBlockedBy", "blockedById", "noParent", "noBlocking", "noBlockedBy"}
+	fieldsInOrder := [...]string{"search", "status", "excludeStatus", "type", "excludeType", "priority", "excludePriority", "tags", "excludeTags", "hasParent", "parentId", "hasBlocking", "blockingId", "isBlocked", "isTransitivelyBlocked", "hasBlockedBy", "blockedById", "noParent", "noBlocking", "noBlockedBy"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -3947,6 +3947,13 @@ func (ec *executionContext) unmarshalInputBeanFilter(ctx context.Context, obj an
 				return it, err
 			}
 			it.IsBlocked = data
+		case "isTransitivelyBlocked":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("isTransitivelyBlocked"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IsTransitivelyBlocked = data
 		case "hasBlockedBy":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hasBlockedBy"))
 			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -44,6 +44,8 @@ type BeanFilter struct {
 	BlockingID *string `json:"blockingId,omitempty"`
 	// Include only beans that are blocked by others (via incoming blocking links or blocked_by field)
 	IsBlocked *bool `json:"isBlocked,omitempty"`
+	// Include only beans that are transitively blocked (blocked themselves or have a blocked ancestor)
+	IsTransitivelyBlocked *bool `json:"isTransitivelyBlocked,omitempty"`
 	// Include only beans that have explicit blocked-by entries
 	HasBlockedBy *bool `json:"hasBlockedBy,omitempty"`
 	// Include only beans blocked by this specific bean ID (via blocked_by field)

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -242,6 +242,8 @@ input BeanFilter {
   blockingId: String
   "Include only beans that are blocked by others (via incoming blocking links or blocked_by field)"
   isBlocked: Boolean
+  "Include only beans that are transitively blocked (blocked themselves or have a blocked ancestor)"
+  isTransitivelyBlocked: Boolean
   "Include only beans that have explicit blocked-by entries"
   hasBlockedBy: Boolean
   "Include only beans blocked by this specific bean ID (via blocked_by field)"


### PR DESCRIPTION
## Summary

Approach 2 (middle ground) for #92: add transitive blocking alongside existing direct blocking.

- Extract `findActiveBlockersLocked` to share logic without lock re-acquisition
- Add `IsTransitivelyBlocked` / `FindTransitiveBlockers` — walk the parent chain collecting ancestor blockers
- Direct `IsBlocked` / `FindActiveBlockers` behavior unchanged
- New `isTransitivelyBlocked` GraphQL filter for callers that want ancestry-aware blocking

Callers choose: `isBlocked` for direct-only, `isTransitivelyBlocked` for ancestor-aware.

## Trade-offs

- More API surface (two concepts instead of one)
- Callers like `ready`, `next`, `blocked` need to decide which to use
- More flexible: you can prep child tasks while the parent epic is blocked

See #92 for design discussion and the simpler approach in #93.

## Test plan

- [x] `go test ./...` passes
- [x] `IsBlocked` unchanged — child of blocked parent still returns false
- [x] `IsTransitivelyBlocked` — child of blocked parent → true
- [x] Grandchild → transitively blocked
- [x] Resolved parent blocker → not transitively blocked
- [x] `FindTransitiveBlockers` returns both direct and ancestor blockers
- [x] `isTransitivelyBlocked` GraphQL filter works in both directions