### PR TITLE
feat: add --exclude-archived flag to TUI

### DIFF
--- a/cmd/tui.go
+++ b/cmd/tui.go
@@ -5,15 +5,22 @@ import (
 	"github.com/hmans/beans/internal/tui"
 )
 
+var tuiExcludeArchived bool
+
 var tuiCmd = &cobra.Command{
 	Use:   "tui",
 	Short: "Open the interactive TUI",
 	Long:  `Opens an interactive terminal user interface for browsing and managing beans.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Override config if flag was explicitly set
+		if cmd.Flags().Changed("exclude-archived") {
+			cfg.TUI.ExcludeArchived = tuiExcludeArchived
+		}
 		return tui.Run(core, cfg)
 	},
 }
 
 func init() {
+	tuiCmd.Flags().BoolVarP(&tuiExcludeArchived, "exclude-archived", "e", false, "Exclude beans with archive statuses (completed, scrapped)")
 	rootCmd.AddCommand(tuiCmd)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,10 +73,16 @@ type PriorityConfig struct {
 // Note: Statuses are no longer stored in config - they are hardcoded like types.
 type Config struct {
 	Beans BeansConfig `yaml:"beans"`
+	TUI   TUIConfig   `yaml:"tui,omitempty"`
 
 	// configDir is the directory containing the config file (not serialized)
 	// Used to resolve relative paths
 	configDir string `yaml:"-"`
+}
+
+// TUIConfig defines settings for the TUI.
+type TUIConfig struct {
+	ExcludeArchived bool `yaml:"exclude_archived,omitempty"`
 }
 
 // BeansConfig defines settings for bean creation.

--- a/internal/graph/filters.go
+++ b/internal/graph/filters.go
@@ -87,6 +87,11 @@ func ApplyFilter(beans []*bean.Bean, filter *model.BeanFilter, core *beancore.Co
 		result = filterByNoBlockedBy(result)
 	}
 
+	// Archive filter
+	if filter.ExcludeArchived != nil && *filter.ExcludeArchived {
+		result = filterByNotArchived(result, core)
+	}
+
 	return result
 }
 
@@ -326,6 +331,17 @@ func filterByNoBlockedBy(beans []*bean.Bean) []*bean.Bean {
 	var result []*bean.Bean
 	for _, b := range beans {
 		if len(b.BlockedBy) == 0 {
+			result = append(result, b)
+		}
+	}
+	return result
+}
+
+// filterByNotArchived filters beans that are not in the archive directory.
+func filterByNotArchived(beans []*bean.Bean, core *beancore.Core) []*bean.Bean {
+	var result []*bean.Bean
+	for _, b := range beans {
+		if !core.IsArchived(b.ID) {
 			result = append(result, b)
 		}
 	}

--- a/internal/graph/generated.go
+++ b/internal/graph/generated.go
@@ -3842,7 +3842,7 @@ func (ec *executionContext) unmarshalInputBeanFilter(ctx context.Context, obj an
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"search", "status", "excludeStatus", "type", "excludeType", "priority", "excludePriority", "tags", "excludeTags", "hasParent", "parentId", "hasBlocking", "blockingId", "isBlocked", "hasBlockedBy", "blockedById", "noParent", "noBlocking", "noBlockedBy"}
+	fieldsInOrder := [...]string{"search", "status", "excludeStatus", "type", "excludeType", "priority", "excludePriority", "tags", "excludeTags", "hasParent", "parentId", "hasBlocking", "blockingId", "isBlocked", "hasBlockedBy", "blockedById", "noParent", "noBlocking", "noBlockedBy", "excludeArchived"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -3982,6 +3982,13 @@ func (ec *executionContext) unmarshalInputBeanFilter(ctx context.Context, obj an
 				return it, err
 			}
 			it.NoBlockedBy = data
+		case "excludeArchived":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("excludeArchived"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ExcludeArchived = data
 		}
 	}
 

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -54,6 +54,8 @@ type BeanFilter struct {
 	NoBlocking *bool `json:"noBlocking,omitempty"`
 	// Exclude beans that have explicit blocked-by entries
 	NoBlockedBy *bool `json:"noBlockedBy,omitempty"`
+	// Exclude beans that are in the archive directory
+	ExcludeArchived *bool `json:"excludeArchived,omitempty"`
 }
 
 // Structured body modifications applied atomically.

--- a/internal/graph/schema.graphqls
+++ b/internal/graph/schema.graphqls
@@ -252,4 +252,6 @@ input BeanFilter {
   noBlocking: Boolean
   "Exclude beans that have explicit blocked-by entries"
   noBlockedBy: Boolean
+  "Exclude beans that are in the archive directory"
+  excludeArchived: Boolean
 }

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -167,10 +167,16 @@ func (m listModel) Init() tea.Cmd {
 }
 
 func (m listModel) loadBeans() tea.Msg {
-	// Build filter if tag filter is set
+	// Build filter based on active filters
 	var filter *model.BeanFilter
-	if m.tagFilter != "" {
-		filter = &model.BeanFilter{Tags: []string{m.tagFilter}}
+	if m.tagFilter != "" || m.config.TUI.ExcludeArchived {
+		filter = &model.BeanFilter{}
+		if m.tagFilter != "" {
+			filter.Tags = []string{m.tagFilter}
+		}
+		if m.config.TUI.ExcludeArchived {
+			filter.ExcludeArchived = &m.config.TUI.ExcludeArchived
+		}
 	}
 
 	// Query filtered beans


### PR DESCRIPTION
## Summary
- Add `-e`/`--exclude-archived` flag to exclude beans that are in the `.beans/archive/` directory
- Add `tui.exclude_archived` config option in `.beans.yml` to set this as default behavior
- Add `excludeArchived` filter to GraphQL BeanFilter schema

## Usage

**Via flag:**
```bash
beans tui -e
beans tui --exclude-archived
```

**Via config (.beans.yml):**
```yaml
tui:
  exclude_archived: true
```

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Manual test: `beans tui -e` excludes archived beans (those in `.beans/archive/`)
- [ ] Manual test: Config option works as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)