### PR TITLE
Show error message when bean creation fails

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -460,7 +460,7 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Status: &draftStatus,
 		})
 		if err != nil {
-			// TODO: Show error to user
+			a.errorMsg = fmt.Sprintf("Failed to create bean: %v", err)
 			a.state = a.previousState
 			return a, nil
 		}


### PR DESCRIPTION
Replace TODO comment with proper error handling. When bean creation fails, display an error message to the user via the app's error message field instead of silently reverting to the previous state.